### PR TITLE
ADD shell builtin 'stack':

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ SRC = linker.ld \
 	tty/keyboard.zig \
 	io/ports.zig \
 	ft/ascii.zig \
+	ft/debug.zig \
 	ft/fmt.zig \
 	ft/ft.zig \
 	ft/io/fixed_buffer_stream.zig \

--- a/build.zig
+++ b/build.zig
@@ -33,6 +33,7 @@ pub fn build(b: *Builder) void {
 
     const build_options = b.addOptions();
     build_options.addOption(bool, "posix", posix);
+    build_options.addOption(std.builtin.OptimizeMode, "optimize", kernel.optimize);
     kernel.addOptions("build_options", build_options);
 
     kernel.addIncludePath(std.Build.LazyPath{.path = "./src/c_headers/"});

--- a/src/ft/ascii.zig
+++ b/src/ft/ascii.zig
@@ -2,6 +2,79 @@ const ft = @import("ft.zig");
 
 pub const whitespace = [_]u8{ ' ', '\t', '\n', '\r', 11, 12 };
 
+pub const control_code = struct {
+    /// Null.
+    pub const nul = 0x00;
+    /// Start of Heading.
+    pub const soh = 0x01;
+    /// Start of Text.
+    pub const stx = 0x02;
+    /// End of Text.
+    pub const etx = 0x03;
+    /// End of Transmission.
+    pub const eot = 0x04;
+    /// Enquiry.
+    pub const enq = 0x05;
+    /// Acknowledge.
+    pub const ack = 0x06;
+    /// Bell, Alert.
+    pub const bel = 0x07;
+    /// Backspace.
+    pub const bs = 0x08;
+    /// Horizontal Tab, Tab ('\t').
+    pub const ht = 0x09;
+    /// Line Feed, Newline ('\n').
+    pub const lf = 0x0A;
+    /// Vertical Tab.
+    pub const vt = 0x0B;
+    /// Form Feed.
+    pub const ff = 0x0C;
+    /// Carriage Return ('\r').
+    pub const cr = 0x0D;
+    /// Shift Out.
+    pub const so = 0x0E;
+    /// Shift In.
+    pub const si = 0x0F;
+    /// Data Link Escape.
+    pub const dle = 0x10;
+    /// Device Control One (XON).
+    pub const dc1 = 0x11;
+    /// Device Control Two.
+    pub const dc2 = 0x12;
+    /// Device Control Three (XOFF).
+    pub const dc3 = 0x13;
+    /// Device Control Four.
+    pub const dc4 = 0x14;
+    /// Negative Acknowledge.
+    pub const nak = 0x15;
+    /// Synchronous Idle.
+    pub const syn = 0x16;
+    /// End of Transmission Block
+    pub const etb = 0x17;
+    /// Cancel.
+    pub const can = 0x18;
+    /// End of Medium.
+    pub const em = 0x19;
+    /// Substitute.
+    pub const sub = 0x1A;
+    /// Escape.
+    pub const esc = 0x1B;
+    /// File Separator.
+    pub const fs = 0x1C;
+    /// Group Separator.
+    pub const gs = 0x1D;
+    /// Record Separator.
+    pub const rs = 0x1E;
+    /// Unit Separator.
+    pub const us = 0x1F;
+    /// Delete.
+    pub const del = 0x7F;
+    /// An alias to `dc1`.
+    pub const xon = dc1;
+    /// An alias to `dc3`.
+    pub const xoff = dc3;
+};
+
 pub fn isDigit(c: u8) bool {
 	return c >= '0' and c <= '9';
 }
@@ -10,4 +83,16 @@ pub fn isWhitespace(c: u8) bool {
 	return for (whitespace) |w| {
 		if (c == w) break true;
 	} else false;
+}
+
+pub fn isASCII(c: u8) bool {
+    return c < 128;
+}
+
+pub fn isControl(c: u8) bool {
+	return c <= control_code.us or c == control_code.del;
+}
+
+pub fn isPrint(c: u8) bool {
+	return isASCII(c) and !isControl(c);
 }

--- a/src/ft/debug.zig
+++ b/src/ft/debug.zig
@@ -1,0 +1,47 @@
+pub const StackIterator = struct {
+	// skip every frame before this address is found
+	first_address: ?usize,
+	fp: usize,
+
+	pub fn init(first_address: ?usize, fp: ?usize) StackIterator {
+		return StackIterator {
+			.first_address = first_address,
+			.fp = fp orelse @frameAddress(),
+		};
+	}
+
+	const pc_offset = @sizeOf(usize);
+
+	pub fn next(self: *StackIterator) ?usize {
+		var address = self.next_internal() orelse return null;
+
+		if (self.first_address) |first_address| {
+			while (address != first_address) {
+				address = self.next_internal() orelse return null;
+			}
+			self.first_address = null;
+		}
+
+		return address;
+	}
+
+	fn next_internal(self: *StackIterator) ?usize {
+		const fp = self.fp;
+
+		// Sanity check.
+		const mem = @import("../ft/ft.zig").mem;
+		if (fp == 0 or !mem.isAligned(fp, @alignOf(usize)))
+		 	return null;
+
+		const new_fp = @as(*const usize, @ptrFromInt(fp)).*;
+
+		if (new_fp != 0 and new_fp < self.fp)
+			return null;
+
+		const new_pc = @as(*const usize, @ptrFromInt(fp + pc_offset)).*;
+
+		self.fp = new_fp;
+
+		return new_pc;
+	}
+};

--- a/src/ft/ft.zig
+++ b/src/ft/ft.zig
@@ -11,4 +11,4 @@ pub const meta = @import("meta.zig");
 
 pub const math = @import("math.zig");
 
-
+pub const debug = @import("debug.zig");

--- a/src/ft/mem.zig
+++ b/src/ft/mem.zig
@@ -62,3 +62,7 @@ pub fn eql(comptime T: type, a: []const T, b: []const T) bool {
 pub fn copyForwards(comptime T: type, dest: []T, src: []const T) void {
     for (dest[0..src.len], src) |*d, s| d.* = s;
 }
+
+pub fn isAligned(addr: usize, alighment: usize) bool {
+	return addr & ~(alighment - 1) == addr;
+}

--- a/src/shell.zig
+++ b/src/shell.zig
@@ -25,8 +25,10 @@ pub fn shell() u8 {
 		// Tokenize the line
 		const args = token.tokenize(@constCast(line)) catch |err| {
 			switch (err) {
-				token.TokenizerError.InvalidQuote => utils.print_error("invalid quotes"),
-				token.TokenizerError.MaxTokensReached => utils.print_error("too many tokens"),
+				token.TokenizerError.InvalidQuote =>
+					utils.print_error("invalid quotes", .{}),
+				token.TokenizerError.MaxTokensReached =>
+					utils.print_error("too many tokens (max: {d})", .{token.max_tokens}),
 			}
 			status_code = 2;
 			continue ;
@@ -43,7 +45,8 @@ pub fn shell() u8 {
 			}
 			else status_code = 1;
 		}
-		if (status_code == 1) utils.print_error("command not found");
+		if (status_code == 1)
+			utils.print_error("{s}: command not found", .{args[0]});
 	}
 	return 0;
 }

--- a/src/shell/builtins.zig
+++ b/src/shell/builtins.zig
@@ -4,7 +4,12 @@ const helpers = @import("helpers.zig");
 const utils = @import("utils.zig");
 
 pub fn stack(_: anytype) usize {
-	utils.print_stack();
+	var ebp: usize = @frameAddress();
+	var esp: usize = 0;
+
+	asm volatile("movl %esp, %[esp]" : [esp] "=r" (esp));
+	utils.dump_stack(ebp, esp);
+	utils.print_stack(ebp, esp);
 	return 0;
 }
 

--- a/src/shell/builtins.zig
+++ b/src/shell/builtins.zig
@@ -4,13 +4,13 @@ const helpers = @import("helpers.zig");
 const utils = @import("utils.zig");
 
 pub fn stack(_: anytype) usize {
-	tty.printk("Stack: WIP\n", .{});
+	utils.print_stack();
 	return 0;
 }
 
 fn _help_available_commands() void {
 	tty.printk(utils.blue ++ "Available commands:\n" ++ utils.reset, .{});
-	inline for (@typeInfo(helpers).Struct.decls) |decl| {
+	inline for (@typeInfo(@This()).Struct.decls) |decl| {
 		tty.printk("  - {s}\n", .{decl.name});
 	}
 }

--- a/src/shell/builtins.zig
+++ b/src/shell/builtins.zig
@@ -35,3 +35,8 @@ pub fn help(data: [][]u8) usize {
 	_help_available_commands();
 	return 2;
 }
+
+pub fn clear(_: [][]u8) usize {
+	tty.printk("\x1b[2J\x1b[H", .{});
+	return 0;
+}

--- a/src/shell/builtins.zig
+++ b/src/shell/builtins.zig
@@ -4,12 +4,12 @@ const helpers = @import("helpers.zig");
 const utils = @import("utils.zig");
 
 pub fn stack(_: anytype) usize {
-	var ebp: usize = @frameAddress();
-	var esp: usize = 0;
-
-	asm volatile("movl %esp, %[esp]" : [esp] "=r" (esp));
-	utils.dump_stack(ebp, esp);
-	utils.print_stack(ebp, esp);
+	if (@import("build_options").optimize != .Debug) {
+		utils.print_error("{s}", .{"The stack builtin is only available in debug mode"});
+		return 2;
+	}
+	utils.dump_stack();
+	utils.print_stack();
 	return 0;
 }
 

--- a/src/shell/builtins.zig
+++ b/src/shell/builtins.zig
@@ -31,12 +31,7 @@ pub fn help(data: [][]u8) usize {
 			return 0;
 		}
 	}
-	tty.printk(
-		utils.red ++
-		"Error:" ++
-		utils.reset ++
-		" Help: There's no help page for \"{s}\"\n", .{ data[1] }
-	);
+	utils.print_error("There's no help page for \"{s}\"\n", .{data[1]});
 	_help_available_commands();
 	return 2;
 }

--- a/src/shell/helpers.zig
+++ b/src/shell/helpers.zig
@@ -22,9 +22,7 @@ fn print_helper(h: Help) void {
 pub fn stack() void {
 	print_helper(Help{
 		.name = "stack",
-		.description =
-			"Prints the stack.\n" ++
-			u.yellow ++ "WARNING" ++ u.reset ++ ": This command is not implemented yet.",
+		.description = "Dispay base pointer's \"traceback\" and dump the stackframes",
 		.usage = null
 	});
 }

--- a/src/shell/helpers.zig
+++ b/src/shell/helpers.zig
@@ -22,7 +22,7 @@ fn print_helper(h: Help) void {
 pub fn stack() void {
 	print_helper(Help{
 		.name = "stack",
-		.description = "Dispay base pointer's \"traceback\" and dump the stackframes",
+		.description = "Display ebp traceback and dump the stack frames",
 		.usage = null
 	});
 }

--- a/src/shell/helpers.zig
+++ b/src/shell/helpers.zig
@@ -36,3 +36,11 @@ pub fn help() void {
 		.usage = "help <command>"
 	});
 }
+
+pub fn clear() void {
+	print_helper(Help{
+		.name = "clear",
+		.description = "Clears the screen",
+		.usage = null
+	});
+}

--- a/src/shell/token.zig
+++ b/src/shell/token.zig
@@ -1,7 +1,7 @@
 const ft = @import("../ft/ft.zig");
 const tty = @import("../tty/tty.zig");
 
-const max_tokens = 32;
+pub const max_tokens = 32;
 
 pub const Tokens = [max_tokens][]u8;
 var tokens: Tokens = undefined;

--- a/src/shell/utils.zig
+++ b/src/shell/utils.zig
@@ -31,9 +31,9 @@ pub fn ensure_newline() void {
 	});
 }
 
-pub fn print_error(msg: []const u8) void {
+pub fn print_error(comptime msg: []const u8, args: anytype) void {
 	ensure_newline();
-	tty.printk(red ++ "Error:" ++ reset ++ " {s}\n", .{msg});
+	tty.printk(red ++ "Error" ++ reset ++ ": " ++ msg ++ "\n", args);
 }
 
 pub fn print_prompt(status_code: usize) void {

--- a/src/shell/utils.zig
+++ b/src/shell/utils.zig
@@ -76,13 +76,20 @@ pub fn memory_dump(start_address: usize, end_address: usize) void {
     }
 }
 
-pub fn print_stack(_ebp: usize, _esp: usize) void {
-	var ebp: usize = _ebp;
-	var esp: usize = _esp;
+pub inline fn print_stack() void {
+	if (@import("build_options").optimize != .Debug) {
+		print_error("{s}", .{"The dump_stack function is only available in debug mode"});
+		return ;
+	}
+
+	var ebp: usize = @frameAddress();
+	var esp: usize = 0;
 	var si: StackIterator = StackIterator.init(null, ebp);
 	var old_fp: usize = 0;
 	var link: bool = false;
 	var pc: ?usize = null;
+
+	asm volatile("movl %esp, %[esp]" : [esp] "=r" (esp));
 
 	tty.printk("{s}EBP{s}, {s}ESP{s}, {s}PC{s}\n", .{
 		yellow, reset,
@@ -129,11 +136,18 @@ pub fn print_stack(_ebp: usize, _esp: usize) void {
 	}
 }
 
-pub fn dump_stack(_ebp: usize, _esp: usize) void {
-	var ebp: usize = _ebp;
-	var esp: usize = _esp;
-	var pc: ?usize = null;
+pub inline fn dump_stack() void {
+	if (@import("build_options").optimize != .Debug) {
+		print_error("{s}", .{"The dump_stack function is only available in debug mode"});
+		return ;
+	}
+
+	var ebp: usize = @frameAddress();
+    var esp: usize = 0;
 	var si: StackIterator = StackIterator.init(null, ebp);
+	var pc: ?usize = null;
+
+    asm volatile("movl %esp, %[esp]" : [esp] "=r" (esp));
 
 	while (true) {
 		const size = si.fp - esp + @sizeOf(usize);

--- a/src/shell/utils.zig
+++ b/src/shell/utils.zig
@@ -91,14 +91,13 @@ pub fn print_stack() void {
 
 	// print ebp "traceback"
 	tty.printk(yellow ++ "(ebp) " ++ reset , .{});
-	while (true) {
-		if (@intFromPtr(_ebp) == @intFromPtr(&stack) + STACK_SIZE) {
-			tty.printk("0x{x} " ++ red ++ "(_entry)\n" ++ reset, .{@intFromPtr(_ebp)});
-			break ;
-		}
-		tty.printk("0x{x} -> ", .{@intFromPtr(_ebp)});
+	while (true) if (@intFromPtr(_ebp) == @intFromPtr(&stack) + STACK_SIZE) {
+		tty.printk("0x{x} " ++ red ++ "(_entry)\n" ++ reset, .{@intFromPtr(_ebp)});
+		break ;
+	} else {
+		tty.printk("0x{x}" ++ yellow ++ "->" ++ reset, .{@intFromPtr(_ebp)});
 		_ebp = @ptrFromInt(_ebp.*);
-	}
+	};
 
 	// print stack frames
 	_ebp = ebp;


### PR DESCRIPTION
Adding a functional stack builtin.
The stack builtin retrieves ebp and esp, calls print_stack and then dump_stack. 
The print_stack function prints each kernel stack frames while dump_stack performs an hex dump on them.

close  #34