### PR TITLE
Rework boot

### DIFF
--- a/src/boot.zig
+++ b/src/boot.zig
@@ -11,25 +11,30 @@ export var stack_bottom : [*]u8 = @as([*]u8, @ptrCast(&stack)) + @sizeOf(@TypeOf
 
 export var multiboot_header : multiboot.header_type align(4) linksection(".multiboot") = multiboot.get_header();
 
+pub var multiboot_info : *multiboot.info_header = undefined;
+
 export fn _entry() callconv(.Naked) noreturn {
 	asm volatile(
 		\\ mov stack_bottom, %esp
 		\\ movl %esp, %ebp
-		\\ movl %ebx, multiboot_info
+		\\ push %ebx
+		\\ push %eax
 		\\ call init
 	);
 	while (true) {}
 }
 
-pub export var multiboot_info : * volatile multiboot.info_header = undefined;
+export fn init(eax : u32, ebx : *multiboot.info_header) void {
+	if (eax == multiboot2_h.MULTIBOOT2_BOOTLOADER_MAGIC) {
+		multiboot_info = ebx;
+	} else @panic("No multiboot2 magic number");
+
+	kernel_main();
+}
 
 pub fn panic(msg: []const u8, _: ?*builtin.StackTrace, _: ?usize) noreturn {
 	const tty = @import("tty/tty.zig");
 
 	tty.printk("panic: {s}\n", .{msg});
 	while (true) {}
-}
-
-export fn init() void {
-	kernel_main();
 }

--- a/src/boot.zig
+++ b/src/boot.zig
@@ -1,4 +1,4 @@
-const kernel_main = @import("kernel.zig").kernel_main;
+const kernel = @import("kernel.zig");
 const multiboot2_h = @import("c_headers.zig").multiboot2_h;
 const multiboot = @import("multiboot.zig");
 const builtin = @import("std").builtin;
@@ -29,7 +29,7 @@ export fn init(eax : u32, ebx : *multiboot.info_header) void {
 		multiboot_info = ebx;
 	} else @panic("No multiboot2 magic number");
 
-	kernel_main();
+	kernel.main();
 }
 
 pub fn panic(msg: []const u8, _: ?*builtin.StackTrace, _: ?usize) noreturn {

--- a/src/boot.zig
+++ b/src/boot.zig
@@ -3,16 +3,17 @@ const multiboot2_h = @import("c_headers.zig").multiboot2_h;
 const multiboot = @import("multiboot.zig");
 const builtin = @import("std").builtin;
 
-export const STACK_SIZE: u32 = 16 * 1024;
+const STACK_SIZE: u32 = 16 * 1024;
 
-export var stack: [STACK_SIZE]u8 align(16) linksection(".bss") = undefined;
+var stack: [STACK_SIZE]u8 align(4096) linksection(".bss") = undefined;
+
+export var stack_bottom : [*]u8 = @as([*]u8, @ptrCast(&stack)) + @sizeOf(@TypeOf(stack));
 
 export var multiboot_header : multiboot.header_type align(4) linksection(".multiboot") = multiboot.get_header();
 
 export fn _entry() callconv(.Naked) noreturn {
 	asm volatile(
-		\\ mov $stack, %esp
-		\\ add STACK_SIZE, %esp
+		\\ mov stack_bottom, %esp
 		\\ movl %esp, %ebp
 		\\ movl %ebx, multiboot_info
 		\\ call init

--- a/src/kernel.zig
+++ b/src/kernel.zig
@@ -2,7 +2,7 @@ const keyboard = @import("./tty/keyboard.zig");
 const printk = @import("./tty/tty.zig").printk;
 const shell = @import("./shell.zig").shell;
 
-pub fn kernel_main() void {
+pub fn main() void {
     printk("hello, \x1b[32m{d}\x1b[37m\n", .{42});
 	_ = shell();
 }

--- a/src/linker.ld
+++ b/src/linker.ld
@@ -1,12 +1,11 @@
 /* The bootloader will look at this image and start execution at the symbol
    designated as the entry point. */
 ENTRY(_entry)
- 
+
 VERSION {
 	VERS_1.0 {
 		local:
-			stack;
-			STACK_SIZE;
+			stack_bottom;
 	};
 }
 

--- a/src/shell/utils.zig
+++ b/src/shell/utils.zig
@@ -2,9 +2,6 @@ const tty = @import("../tty/tty.zig");
 const ft = @import("../ft/ft.zig");
 const StackIterator = ft.debug.StackIterator;
 
-extern var STACK_SIZE: usize;
-extern var stack: u8;
-
 pub const inverse = "\x1b[7m";
 pub const red = "\x1b[31m";
 pub const green = "\x1b[32m";


### PR DESCRIPTION
only export stack_bottom instead of stack and STACK_SIZE

rework bootloader interface:
- _entry is now only calling the init function with eax and ebx as arguments
- add a check for eax in init

rename kernel_main to main (since we use zig namespaces)

resolve #53