### PR TITLE
REWORK kernel mapping:

### DIFF
--- a/src/memory/paging.zig
+++ b/src/memory/paging.zig
@@ -32,7 +32,7 @@ pub const page = [page_size]u8;
 
 pub const PhysicalPtr = u32;
 pub const VirtualPtr = *allowzero void;
-pub const VirtualPagePtr = *allowzero page;
+pub const VirtualPagePtr = *allowzero align(4096) page;
 
 pub const dir_idx = u10;
 pub const table_idx = u10;
@@ -96,8 +96,8 @@ pub const low_half = 0xC0000000;
 pub const kernel_virtual_space_top = temporary_page;
 pub const kernel_virtual_space_size = kernel_virtual_space_top - low_half;
 
-pub const page_dir_ptr : *[page_directory_size]page_directory_entry = @ptrFromInt(page_dir);
-pub const page_table_table_ptr : *[page_table_size]page_table_entry = @ptrFromInt(page_table_table);
+pub const page_dir_ptr : * align(4096) [page_directory_size]page_directory_entry = @ptrFromInt(page_dir);
+pub const page_table_table_ptr : * align(4096) [page_table_size]page_table_entry = @ptrFromInt(page_table_table);
 // pub const kernel_tables_ptr : *[256][page_table_size]page_table_entry = @ptrFromInt(kernel_tables);
 
 pub fn is_user_space(p : VirtualPagePtr) bool {

--- a/src/memory/virtual_addresses_allocator.zig
+++ b/src/memory/virtual_addresses_allocator.zig
@@ -10,9 +10,7 @@ pub fn VirtualAddressesAllocator(comptime PageAllocator : type) type {
 
 		free_nodes : ?*Node = null,
 
-		node_pages : ?*NodePage = null,
-
-		boostrap_page : NodePage align(paging.page_size) = .{},
+		node_pages : ?* allowzero NodePage = null,
 
 		used_space : usize = 0,
 
@@ -21,11 +19,11 @@ pub fn VirtualAddressesAllocator(comptime PageAllocator : type) type {
 			Address
 		};
 
-		const Node = extern struct {
+		const Node = struct {
 			avl : [2]AVL_hdr = .{.{}, .{}},
 			next : ?*@This() = null,
 
-			const AVL_hdr = extern struct {
+			const AVL_hdr = struct {
 				l : ?*Node = null,
 				r : ?*Node = null,
 				p : ?*Node = null,
@@ -33,12 +31,12 @@ pub fn VirtualAddressesAllocator(comptime PageAllocator : type) type {
 			};
 		};
 
-		const NodePage = extern struct {
+		const NodePage = struct {
 			hdr : Header = .{},
 			nodes : [nodes_per_pages]Node = undefined,
 
-			const Header = extern struct {
-				next : ?*NodePage = null,
+			const Header = struct {
+				next : ?* allowzero NodePage = null,
 				first_node : usize = 0,
 				free_nodes_count : usize = (paging.page_size - @sizeOf(@This())) / @sizeOf(Node),
 			};
@@ -304,7 +302,7 @@ pub fn VirtualAddressesAllocator(comptime PageAllocator : type) type {
 			else return null;
 		}
 
-		fn page_of_node(n : *Node) *NodePage {
+		fn page_of_node(n : *Node) * allowzero NodePage {
 			return @ptrFromInt(ft.mem.alignBackward(usize, @intFromPtr(n), paging.page_size));
 		}
 
@@ -325,7 +323,7 @@ pub fn VirtualAddressesAllocator(comptime PageAllocator : type) type {
 				}
 			}
 
-			const new_page : *NodePage = @ptrCast(@alignCast(try self.pageAllocator.alloc_pages(1)));
+			const new_page : * allowzero NodePage = @ptrCast((try self.pageAllocator.alloc_pages(1)));
 
 			new_page.* = .{};
 			new_page.hdr.next = self.node_pages;

--- a/src/trampoline.zig
+++ b/src/trampoline.zig
@@ -1,7 +1,7 @@
 const paging = @import("memory/paging.zig");
 const ft = @import("ft/ft.zig");
 
-const kernel_size = 0x10_000_000;
+pub const kernel_size = 0x10_000_000;
 
 const page_count = ft.math.divCeil(comptime_int, kernel_size, paging.page_size) catch unreachable;
 
@@ -19,56 +19,22 @@ fn get_page_tables() [table_count][1024]paging.page_table_entry {
 	return ret;
 }
 
-export const page_tables : ([table_count][1024]paging.page_table_entry) align(4096) linksection(".bootstrap")  = get_page_tables();
+pub export const page_tables : ([table_count][1024]paging.page_table_entry) align(4096) linksection(".bootstrap")  = get_page_tables();
 
-fn get_page_directory() [1024]paging.page_directory_entry
-{
-	var ret : [1024]paging.page_directory_entry = .{paging.page_directory_entry{}} ** 1024;
-	for (0..table_count) |i| {
-		ret[i].present = true;
-		ret[i].writable = true;
-		ret[i].address_fragment = i;
-		ret[768 + i] = ret[i];
-	}
-	return ret;
-}
-
-
-pub const page_directory : [1024]paging.page_directory_entry align(4096) linksection(".bootstrap") = get_page_directory();
+pub var page_directory : [1024]paging.page_directory_entry align(4096) linksection(".bootstrap") = undefined;
 
 export fn trampoline_jump() linksection(".bootstrap_code") callconv(.C) void {
 
-	asm volatile (
-	 \\ loop:
-	 \\ cmpl $0, %edx
-	 \\ je loop_end
-	 \\ dec %edx
-	 // \\ mov (%eax, %edx, 4), %ecx
-	 \\ movl %edx, %ecx
-	 \\ shll $12 , %ecx
-	 \\ addl %ebx, %ecx
-	 \\ orl $3, %ecx
-	 \\ mov %ecx, (%eax, %edx, 4)
-	 \\ addl $768, %edx
-	 \\ mov %ecx, (%eax, %edx, 4)
-	 \\ subl $768, %edx
-	 \\ jmp loop
-	 \\ loop_end:
-	 :
-	 : [_] "{eax}" (&page_directory),
-	   [_] "{ebx}" (@intFromPtr(&page_tables)),
-	   [_] "{edx}" (table_count),
-	);
+	// fill the page directory
+	for (0..table_count) |t| {
+		page_directory[t] = .{.present = true, .writable = true, .address_fragment = @intCast(t + @intFromPtr(&page_tables) / paging.page_size)};
+		page_directory[768 + t] = page_directory[t];
+	}
 
-	asm volatile(
-	\\ mov %eax, %ecx
-	\\ orl $3, %ecx
-	\\ mov %ecx, (%eax, %ebx, 4)
-	 :
-	 : [_] "{eax}" (&page_directory),
-	   [_] "{ebx}" (paging.page_dir >> 22),
-	);
+	// add one entry for the page directory itself
+	@as(*[1024]u32, @ptrCast(&page_directory))[paging.page_dir >> 22] = @intFromPtr(&page_directory) | 3;
 
+	// load the page directory and enable paging
 	asm volatile(
 	 \\ mov %eax, %cr3
 	 \\ mov %cr0, %eax
@@ -77,4 +43,9 @@ export fn trampoline_jump() linksection(".bootstrap_code") callconv(.C) void {
 	 :
 	 : [_] "{eax}" (&page_directory),
 	);
+}
+
+/// remove identity paging of the kernel
+pub fn clean() void {
+	@memset(paging.page_dir_ptr[0..(paging.low_half >> 22)], paging.page_directory_entry{});
 }


### PR DESCRIPTION
- remove identity mapping at boot
- shrink virtual space taken by the kernel
- partial freeing of the bootstrap section

close #83 