### PR TITLE
UPDATE: better printk

### DIFF
--- a/src/ft/fmt.zig
+++ b/src/ft/fmt.zig
@@ -344,7 +344,7 @@ pub fn formatObj(obj: anytype, comptime specifier : Specifier, comptime options:
 				.lower_hexa, .upper_hexa => try formatInt(obj, 16, if (specifier == .lower_hexa) Case.lower else Case.upper, options, writer),
 				.octal => try formatInt(obj, 8, Case.lower, options, writer),
 				.binary => try formatInt(obj, 2, Case.lower, options, writer),
-				else => @compileError("invalid specifier")
+				else => try formatInt(obj, 10, Case.lower, options, writer),
 			}
 		},
 		.Pointer => |pointer| {

--- a/src/ft/io/writer.zig
+++ b/src/ft/io/writer.zig
@@ -2,13 +2,15 @@ const ft = @import("../ft.zig");
 
 pub fn Writer(
 	comptime Context: type,
-	comptime Error: type,
-	comptime callback: fn(context: Context, bytes: []const u8) Error!usize,
+	comptime _Error: type,
+	comptime callback: fn(context: Context, bytes: []const u8) _Error!usize,
 ) type {
 	return struct {
 		context: Context,
 
 		const Self = @This();
+
+		pub const Error = _Error;
 
 		pub fn print(self: Self, comptime format: []const u8, args: anytype) Error!void {
 			return ft.fmt.format(self, format, args);

--- a/src/tty/buffer_writer.zig
+++ b/src/tty/buffer_writer.zig
@@ -1,0 +1,56 @@
+const ft = @import("../ft/ft.zig");
+
+
+/// this class wrap a Writer and provide bufferization
+pub fn BufferWriter(
+	comptime Context: type,
+	comptime Error: type,
+	comptime callback: fn(context: Context, bytes: []const u8) Error!usize,
+	comptime size : comptime_int
+) type {
+	if (size <= 0)
+		@compileError("buffer writer size must be greater than 0");
+	return struct {
+		context: Context,
+		buffer : [size]u8 = undefined,
+		index : usize = 0,
+
+		const Self = @This();
+
+		pub fn print(self: *Self, comptime format: []const u8, args: anytype) Error!void {
+			return ft.fmt.format(self, format, args);
+		}
+
+		pub fn flush(self: *Self) Error!void {
+			_ = try callback(self.context, self.buffer[0..self.index]);
+			self.index = 0;
+		}
+
+		pub fn write(self: *Self, bytes: []const u8) Error!usize {
+			if (bytes.len +| self.index > self.buffer.len) {
+				try self.flush();
+				return callback(self.context, bytes);
+			}
+			else {
+				for (bytes) |b| {
+					self.buffer[self.index] = b;
+					self.index += 1;
+					if (b == '\n')
+						try self.flush();
+				}
+				return bytes.len;
+			}
+		}
+
+		pub fn writeAll(self: *Self, bytes: []const u8) Error!void {
+			var offset: usize = 0;
+			while (offset != bytes.len) {
+				offset += try self.write(bytes[offset..]);
+			}
+		}
+
+		pub fn writeByte(self: *Self, byte: u8) Error!void {
+			_ = try self.write(&([1]u8{byte}));
+		}
+	};
+}

--- a/src/tty/tty.zig
+++ b/src/tty/tty.zig
@@ -485,6 +485,14 @@ pub fn TtyN(comptime history_size: u32) type {
             self.view();
         }
 
+		/// reset scroll to the bottom of the terminal
+		pub fn reset_scroll(self : *Self) void {
+			if (self.scroll_offset != 0)
+			{
+				self.scroll_offset = 0;
+				self.view();
+			}
+		}
 
 		/// enable vga cursor
 		pub fn enable_cursor(_: *Self) void {


### PR DESCRIPTION
### format
rework code structure and add support for:
- optionals
- pointers
- enums

### tty
add BufferWriter class that wrap a Writer with bufferization.
add an array of BufferWriters in tty.
recode tty.printk in order to use the buffers

printk is now BlAzInGlY fAsT!!!

### keyboard
add shortcuts to scroll page by page (shift-pgup, shift-pgdown)

reset the scroll when an input is sent to the terminal

closes #61 