### PR TITLE
FIX PS/2 Driver:

### DIFF
--- a/src/drivers/ps2/ps2.zig
+++ b/src/drivers/ps2/ps2.zig
@@ -287,8 +287,8 @@ pub fn init() void {
 	// if (available_ports.p2 == 1)
 	// 	enable_second_port();
 	if (available_ports.p1 == 1) {
-		enable_first_port();
 		enable_translation();
+		enable_first_port();
 	}
 	log("Controller initialized", .{}, 0);
 }


### PR DESCRIPTION
Enabling first port after enabling translation.
When enabling translation, the config is saved first and restored after enabling translation, thus if first port is already enabled it can scramble the data port and broke the configuration when restored.

close #81