### PR TITLE
UPDATE interrupts

### DIFF
--- a/src/boot.zig
+++ b/src/boot.zig
@@ -70,6 +70,8 @@ export fn init(eax: u32, ebx: u32) callconv(.C) void {
 
     @import("drivers/ps2/ps2.zig").init();
 
+    @import("tty/keyboard.zig").init();
+
     @import("./drivers/acpi/acpi.zig").init();
 
     kernel.main();

--- a/src/tty/keyboard.zig
+++ b/src/tty/keyboard.zig
@@ -1,6 +1,7 @@
 const ft = @import("../ft/ft.zig");
 const tty = @import("tty.zig");
 const ps2 = @import("../drivers/ps2/ps2.zig");
+const pic = @import("../drivers/pic/pic.zig");
 const keymap = @import("keyboard/keymap.zig");
 const scanmap = @import("keyboard/scanmap.zig");
 const scanmap_normal = scanmap.scanmap_normal;
@@ -160,9 +161,16 @@ pub fn handler() callconv(.Interrupt) void {
             },
         },
     };
-    @import("../drivers/pic/pic.zig").ack();
+    pic.ack();
 }
 
 fn is_key_available() bool {
     return ps2.get_status().output_buffer == 1;
+}
+
+pub fn init() void {
+    const interrupts = @import("../interrupts.zig");
+    ps2.set_first_port_interrupts(true);
+    interrupts.set_intr_gate(pic.IRQS.Keyboard, interrupts.Handler{ .noerr = &handler });
+    pic.enable_irq(pic.IRQS.Keyboard);
 }


### PR DESCRIPTION
rework gdt:
move assembly to cpu.zig, turn gdtr into a local variable, add get_selector function

UPDATE interrupts:
- add enum for exception
- add get_id function to get the numeric id of an interrupt
- add setters to set handlers for interrupts
- rework keyboard initialization