### PR TITLE
REWORK panic:

### DIFF
--- a/src/drivers/pic/pic.zig
+++ b/src/drivers/pic/pic.zig
@@ -48,10 +48,20 @@ pub fn enable_irq(irq: IRQS) void {
     cpu.outb(port_id.port, mask & ~(@as(u8, 1) << @truncate(port_id.id)));
 }
 
+pub fn enable_all_irqs() void {
+    cpu.outb(cpu.Ports.pic_master_data, 0x00);
+    cpu.outb(cpu.Ports.pic_slave_data, 0x00);
+}
+
 pub fn disable_irq(irq: IRQS) void {
     const port_id = get_irq_port_id(irq);
     const mask = cpu.inb(port_id.port);
     cpu.outb(port_id.port, mask | (@as(u8, 1) << @truncate(port_id.id)));
+}
+
+pub fn disable_all_irqs() void {
+    cpu.outb(cpu.Ports.pic_master_data, 0xff);
+    cpu.outb(cpu.Ports.pic_slave_data, 0xff);
 }
 
 pub fn remap(offset1: u8, offset2: u8) void {

--- a/src/logger.zig
+++ b/src/logger.zig
@@ -25,6 +25,7 @@ pub fn kernel_log(
         args,
     );
     if (message_level == .err and scope == .default) {
+        @import("cpu.zig").disable_interrupts();
         if (@import("build_options").ci) {
             var com_port = @import("shell/ci/shell.zig").com_port_1;
             var packet = @import("shell/ci/packet.zig").Packet([]u8).init(com_port.get_writer().any());
@@ -38,6 +39,9 @@ pub fn kernel_log(
             screen_of_death(format, args);
             while (true) @import("cpu.zig").halt();
         } else {
+            @import("drivers/pic/pic.zig").disable_all_irqs();
+            @import("drivers/pic/pic.zig").enable_irq(.Keyboard);
+            @import("cpu.zig").enable_interrupts();
             tty.get_tty().config.c_lflag.ECHO = false;
             while (true) {
                 @import("cpu.zig").halt();


### PR DESCRIPTION
Updating the PIC allowing to enable / disable all irqs at once,
Reworking the panic logic in Debug mode to disable all irqs except Keyboard and ensure interrupts are enable.

close #146 