### PR TITLE
REWORK interrupt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ BUILD_ARGS ?= --summary all --verbose
 ZIG ?= zig
 
 # get the last optimize option
-OPTIMIZE ?= $(shell echo $$(ls ".optimize-*" 2>/dev/null || echo Debug) | cut -d'-' -f2)
+OPTIMIZE ?= $(shell echo $$(ls ".optimize-"* 2>/dev/null || echo Debug) | cut -d'-' -f2)
 
 .PHONY: all
 all: build
@@ -15,7 +15,7 @@ run: build
 	qemu-system-i386 -cdrom kfs.iso
 
 .PHONY: build
-build:
+build: .optimize-$(OPTIMIZE)
 	$(ZIG) build -Doptimize=$(OPTIMIZE) $(BUILD_ARGS)
 
 .PHONY: debug

--- a/src/boot.zig
+++ b/src/boot.zig
@@ -63,6 +63,8 @@ export fn init(eax: u32, ebx: u32) callconv(.C) void {
 
     @import("gdt.zig").init();
 
+    @import("drivers/pic/pic.zig").init();
+
     @import("interrupts.zig").init();
 
     @import("memory.zig").init();

--- a/src/shell/ci/shell.zig
+++ b/src/shell/ci/shell.zig
@@ -10,15 +10,15 @@ pub var com_port_1: Serial = Serial.init(.com_port_1);
 const InterruptFrame = interrupts.InterruptFrame;
 
 fn pic_handler(_: *InterruptFrame) callconv(.Interrupt) void {
-    pic.ack();
+    pic.ack(.COM1);
 }
 
 pub fn on_init(shell: *Shell) void {
     com_port_1.activate() catch return ft.log.err("Failed to enable COM1", .{});
     ft.log.info("COM1 enabled", .{});
 
-    interrupts.set_trap_gate(pic.IRQS.COM1, interrupts.Handler{ .noerr = &pic_handler });
-    pic.enable_irq(pic.IRQS.COM1);
+    interrupts.set_trap_gate(pic.IRQ.COM1, interrupts.Handler{ .noerr = &pic_handler });
+    pic.enable_irq(pic.IRQ.COM1);
     _ = shell.writer.write("COM1 IRQ enabled\n") catch {};
 }
 

--- a/src/tty/keyboard.zig
+++ b/src/tty/keyboard.zig
@@ -163,7 +163,7 @@ pub fn handler(_: *InterruptFrame) callconv(.Interrupt) void {
             },
         },
     };
-    pic.ack();
+    pic.ack(.Keyboard);
 }
 
 fn is_key_available() bool {
@@ -173,6 +173,6 @@ fn is_key_available() bool {
 pub fn init() void {
     const interrupts = @import("../interrupts.zig");
     ps2.set_first_port_interrupts(true);
-    interrupts.set_intr_gate(pic.IRQS.Keyboard, interrupts.Handler{ .noerr = &handler });
-    pic.enable_irq(pic.IRQS.Keyboard);
+    interrupts.set_intr_gate(pic.IRQ.Keyboard, interrupts.Handler{ .noerr = &handler });
+    pic.enable_irq(pic.IRQ.Keyboard);
 }


### PR DESCRIPTION
Reworking default_handler for greater clarity.

It now take an ``enum{ except, except_err, irq, interrupt }``.
- ``.except`` for cpu exceptions that doesn't take arguments
- ``.except_err`` for cpu exceptions that take an error code as argument
- ``.irq`` for the interrupt requested by the PIC
- ``.interrupt`` for any other interrupt

close #148 