### PR TITLE
Add color to the logger scope

### DIFF
--- a/src/logger.zig
+++ b/src/logger.zig
@@ -21,7 +21,7 @@ pub fn kernel_log(
 
     tty.printk(
         "[" ++ color ++ level_str ++ colors.reset ++ "] " ++
-            (" " ** padding) ++ scope_str ++ format ++ "\n",
+            (" " ** padding) ++ colors.white_dim ++ scope_str ++ colors.reset ++ format ++ "\n",
         args,
     );
     if (message_level == .err and scope == .default) {

--- a/src/misc/colors.zig
+++ b/src/misc/colors.zig
@@ -12,6 +12,24 @@ pub const magenta = "\x1b[35m";
 pub const cyan = "\x1b[36m";
 pub const white = "\x1b[37m";
 
+pub const black_bold = bold ++ black;
+pub const red_bold = bold ++ red;
+pub const green_bold = bold ++ green;
+pub const yellow_bold = bold ++ yellow;
+pub const blue_bold = bold ++ blue;
+pub const magenta_bold = bold ++ magenta;
+pub const cyan_bold = bold ++ cyan;
+pub const white_bold = bold ++ white;
+
+pub const black_dim = dim ++ black;
+pub const red_dim = dim ++ red;
+pub const green_dim = dim ++ green;
+pub const yellow_dim = dim ++ yellow;
+pub const blue_dim = dim ++ blue;
+pub const magenta_dim = dim ++ magenta;
+pub const cyan_dim = dim ++ cyan;
+pub const white_dim = dim ++ white;
+
 pub const bg_black = "\x1b[40m";
 pub const bg_red = "\x1b[41m";
 pub const bg_green = "\x1b[42m";


### PR DESCRIPTION
Simply adding some color to the scope to better differentiate it from the log message.

![image](https://github.com/riblanc/kfs/assets/59930230/592a6d22-d30a-44b9-b656-9e5d4a99f5ac)